### PR TITLE
Adds Validation Errors to the Serializers Errors Plugin

### DIFF
--- a/Lib/Error/BaseSerializerException.php
+++ b/Lib/Error/BaseSerializerException.php
@@ -17,36 +17,36 @@ class BaseSerializerException extends CakeException {
 	 * occurrence to occurrence of the problem, except for purposes of
 	 * localization.
 	 *
-	 * @var null
+	 * @var string
 	 */
-	public $title = 'Base Serializer Exception';
+	public $title = "Base Serializer Exception";
 
 	/**
 	 * A human-readable explanation specific to this occurrence of the problem.
 	 *
-	 * @var null
+	 * @var string
 	 */
-	public $detail = 'Base Serializer Exception';
+	public $detail = "Base Serializer Exception";
 
 	/**
 	 * An application-specific error code, expressed as a string value.
 	 *
-	 * @var null
+	 * @var string
 	 */
-	public $code = 400;
+	public $code = "400";
 
 	/**
 	 * A URI that MAY yield further details about this particular occurrence
 	 * of the problem.
 	 *
-	 * @var null
+	 * @var string
 	 */
 	public $href = null;
 
 	/**
 	 * A unique identifier for this particular occurrence of the problem.
 	 *
-	 * @var null
+	 * @var string
 	 */
 	public $id = null;
 
@@ -54,25 +54,25 @@ class BaseSerializerException extends CakeException {
 	 * The HTTP status code applicable to this problem, expressed as a string
 	 * value.
 	 *
-	 * @var null
+	 * @var integer
 	 */
-	public $status = null;
+	public $status = 400;
 
 	/**
 	 * Associated resources which can be dereferenced from the request document.
 	 *
-	 * @var null
+	 * @var array
 	 */
-	public $links = null;
+	public $links = array();
 
 	/**
 	 * The relative path to the relevant attribute within the associated
 	 * resource(s). Only appropriate for problems that apply to a single
 	 * resource or type of resource.
 	 *
-	 * @var null
+	 * @var array
 	 */
-	public $path = null;
+	public $path = array();
 
 	/**
 	 * Constructs a new instance of the base BaseJsonApiException
@@ -105,6 +105,76 @@ class BaseSerializerException extends CakeException {
 		$this->paths = $paths;
 
 		// construct the parent CakeException class
+		parent::__construct($this->title, $this->status);
+	}
+
+	/**
+	 * magic method __call, checks if the method called is a property of the class,
+	 * and returns the property if it is, else throws BadMethodCallException
+	 *
+	 * @param string $name [description]
+	 * @param array $args [description]
+	 * @return multi
+	 * @throws BadMethodCallException if the Method and Property does not exist
+	 */
+	public function __call($name, $args) {
+		if (property_exists($this, $name)) {
+			return $this->{$name};
+		}
+
+		throw new BadMethodCallException("No method or property ::{$name} for this class");
+	}
+
+}
+
+/**
+ * ValidationBaseSerializerException
+ *
+ * a generic exception to use when validation errors occur
+ */
+class ValidationBaseSerializerException extends CakeException {
+
+	/**
+	 * A short, human-readable summary of the problem. It SHOULD NOT change from
+	 * occurrence to occurrence of the problem, except for purposes of
+	 * localization.
+	 *
+	 * @var string
+	 */
+	public $title = 'Base Validation Serializer Exception';
+
+	/**
+	 * An array of Validation Errors that the Cake Model has reported
+	 *
+	 * @var array
+	 */
+	public $validationErrors = array();
+
+	/**
+	 * The HTTP status code applicable to this problem, expressed as a string
+	 * value, default is 422
+	 *
+	 * @var integer
+	 */
+	public $status = 422;
+
+	/**
+	 * Constructs a new instance of the base ValidationFailedJsonApiException
+	 *
+	 * @param string $title The title of the exception, passed to parent CakeException::__construct
+	 * @param array $validationErrors An array of Validation Errors the Cake Model has reported
+	 * @param int $status The http status code of the error, passed to parent CakeException::__construct
+	 */
+	public function __construct(
+		$title = 'Validation Failed',
+		array $validationErrors = array(),
+		$status = 422
+	) {
+		// Set the passed in properties to the properties of the Object
+		$this->title = $title;
+		$this->validationErrors = $validationErrors;
+		$this->status = $status;
+
 		parent::__construct($this->title, $this->status);
 	}
 

--- a/Lib/Error/BaseSerializerException.php
+++ b/Lib/Error/BaseSerializerException.php
@@ -132,7 +132,7 @@ class BaseSerializerException extends CakeException {
  *
  * a generic exception to use when validation errors occur
  */
-class ValidationBaseSerializerException extends CakeException {
+class ValidationBaseSerializerException extends BaseSerializerException {
 
 	/**
 	 * A short, human-readable summary of the problem. It SHOULD NOT change from
@@ -144,13 +144,6 @@ class ValidationBaseSerializerException extends CakeException {
 	public $title = 'Base Validation Serializer Exception';
 
 	/**
-	 * An array of Validation Errors that the Cake Model has reported
-	 *
-	 * @var array
-	 */
-	public $validationErrors = array();
-
-	/**
 	 * The HTTP status code applicable to this problem, expressed as a string
 	 * value, default is 422
 	 *
@@ -159,23 +152,34 @@ class ValidationBaseSerializerException extends CakeException {
 	public $status = 422;
 
 	/**
-	 * Constructs a new instance of the base ValidationFailedJsonApiException
+	 * A CakePHP Model array of validation errors
+	 *
+	 * @var array
+	 */
+	public $validationErrors = array();
+
+	/**
+	 * Constructs a new instance of the base BaseJsonApiException
 	 *
 	 * @param string $title The title of the exception, passed to parent CakeException::__construct
-	 * @param array $validationErrors An array of Validation Errors the Cake Model has reported
+	 * @param array $validationErrors A CakePHP Model array of validation errors
 	 * @param int $status The http status code of the error, passed to parent CakeException::__construct
+	 * @param string $id A unique identifier for this particular occurrence of the problem.
+	 * @param string $href A URI that MAY yield further details about this particular occurrence of the problem.
+	 * @param array $links An array of JSON Pointers [RFC6901] to the associated resource(s) within the request document [e.g. ["/data"] for a primary data object].
+	 * @param array $paths An array of JSON Pointers to the relevant attribute(s) within the associated resource(s) in the request document. Each path MUST be relative to the resource path(s) expressed in the error object's "links" member [e.g. ["/first-name", "/last-name"] to reference a couple attributes].
 	 */
 	public function __construct(
 		$title = 'Validation Failed',
 		array $validationErrors = array(),
-		$status = 422
+		$status = 422,
+		$id = null,
+		$href = null,
+		$links = null,
+		$paths = null
 	) {
-		// Set the passed in properties to the properties of the Object
-		$this->title = $title;
 		$this->validationErrors = $validationErrors;
-		$this->status = $status;
-
-		parent::__construct($this->title, $this->status);
+		parent::__construct($title, $validationErrors, $status, $id, $href, $links, $paths);
 	}
 
 	/**

--- a/Lib/Error/BaseSerializerException.php
+++ b/Lib/Error/BaseSerializerException.php
@@ -54,7 +54,7 @@ class BaseSerializerException extends CakeException {
 	 * The HTTP status code applicable to this problem, expressed as a string
 	 * value.
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	public $status = 400;
 
@@ -154,7 +154,7 @@ class ValidationBaseSerializerException extends CakeException {
 	 * The HTTP status code applicable to this problem, expressed as a string
 	 * value, default is 422
 	 *
-	 * @var integer
+	 * @var int
 	 */
 	public $status = 422;
 

--- a/Lib/Error/SerializerExceptionRenderer.php
+++ b/Lib/Error/SerializerExceptionRenderer.php
@@ -450,7 +450,7 @@ class SerializerExceptionRenderer extends ExceptionRenderer {
 
 		// set the errors object to match JsonApi's standard
 		$errors = array(
-			'errors' =>  $error->validationErrors(),
+			'errors' => $error->validationErrors(),
 		);
 
 		// json encode the errors

--- a/Lib/Error/SerializerExceptionRenderer.php
+++ b/Lib/Error/SerializerExceptionRenderer.php
@@ -34,9 +34,10 @@ class SerializerExceptionRenderer extends ExceptionRenderer {
 			return $this->renderCakeException($this->error);
 		} elseif ($this->error instanceof HttpException) {
 			return $this->renderHttpException($this->error);
+		} else {
+			// This isn't a standard CakeException, render it using the default error500 method
+			return $this->error500($this->error);
 		}
-
-		return parent::render();
 	}
 
 	/**

--- a/Lib/Error/SerializerExceptionRenderer.php
+++ b/Lib/Error/SerializerExceptionRenderer.php
@@ -34,9 +34,9 @@ class SerializerExceptionRenderer extends ExceptionRenderer {
 			return $this->renderCakeException($this->error);
 		} elseif ($this->error instanceof HttpException) {
 			return $this->renderHttpException($this->error);
-		} else {
-			return parent::render();
 		}
+
+		return parent::render();
 	}
 
 	/**

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CakePHP SerializersErrors Serializes and Renders `HttpException`s, `CakeExceptio
 $ composer require loadsys/cakephp-serializers-errors
 ````
 
-## Usage ##
+## Usage
 
 * Add this plugin to your application by adding this line to your bootstrap.php
 
@@ -48,6 +48,109 @@ JSON formated errors or standard HTML responses, differing on the request `Accep
 * If you build custom Exceptions that extend `BaseSerializerException` you get 
 Exceptions that enable the full feature set of [JSON API errors](http://jsonapi.org/format/#errors)
 in addition to be rendering in the pattern described above.
+
+## Sample Responses
+
+Here are some sample response for the different Exception classes.
+
+### BaseSerializerException
+
+#### Accepts: application/vnd.api+json
+
+Matches the format expected in [JSON API](http://jsonapi.org/format/#errors)
+
+```php
+throw new BaseSerializerException("This is a message.", "Something failed", 400, "Custom ID For Error", "http://docs.domain.com/api/v1/custom-id-for-error", array(), array())
+```
+
+```javascript
+{
+	"errors": {
+		"id": "Custom ID For Error",
+		"href": "http://docs.domain.com/api/v1/custom-id-for-error",
+		"status": "400",
+		"code": "400",
+		"title": "This is a message.",
+		"detail": "Something failed",
+		"links": [],
+		"paths": []
+	}
+}
+```
+
+#### Accepts: application/json
+
+```php
+throw new BaseSerializerException("This is a message.", "Something failed", 400, "Custom ID For Error", "http://docs.domain.com/api/v1/custom-id-for-error", array(), array())
+```
+
+```javascript
+{
+	"id": "Custom ID For Error",
+	"href": "http://docs.domain.com/api/v1/custom-id-for-error",
+	"status": "400",
+	"code": "400",
+	"detail": "Something failed",
+	"links": [],
+	"paths": []
+}
+```
+
+### ValidationBaseSerializerException
+
+#### Accepts: application/vnd.api+json
+
+Matches the format expected in [JSON API](http://jsonapi.org/format/#errors)
+
+```php
+throw new ValidationBaseSerializerException("This is a message.", $this->ModelName->invalidFields(), 422, "Custom ID For Error", "http://docs.domain.com/api/v1/custom-id-for-error", array(), array())
+```
+
+```javascript
+{
+	"errors": {
+		"id": "Custom ID For Error",
+		"href": "http://docs.domain.com/api/v1/custom-id-for-error",
+		"status": "400",
+		"code": "400",
+		"title": "This is a message.",
+		"detail": {
+			"username": [
+				"Username can not be empty",
+				"Username can only be alphanumeric characters"
+			],
+			"first_name": [
+				"First Name must be longer than 4 characters"
+			]
+		},
+		"links": [],
+		"paths": []
+	}
+}
+```
+
+#### Accepts: application/json
+
+Matches the format expected in [Ember.js DS.Errors Class](http://emberjs.com/api/data/classes/DS.Errors.html)
+
+```php
+$invalidFields = $this->ModelName->invalidFields();
+throw new ValidationBaseSerializerException("This is a message.", $invalidFields, 422, "Custom ID For Error", "http://docs.domain.com/api/v1/custom-id-for-error", array(), array())
+```
+
+```javascript
+{
+	"errors": {
+		"username": [
+			"Username can not be empty",
+			"Username can only be alphanumeric characters"
+		],
+		"first_name": [
+			"First Name must be longer than 4 characters"
+		]
+	}
+}
+```
 
 ## Contributing
 

--- a/Test/Case/Lib/Error/BaseSerializerExceptionTest.php
+++ b/Test/Case/Lib/Error/BaseSerializerExceptionTest.php
@@ -35,7 +35,7 @@ class BaseSerializerExceptionTest extends CakeTestCase {
 	 *
 	 * @return void
 	 */
-	public function testConstructor() {
+	public function testBaseConstructor() {
 		$title = "New Title";
 		$detail = "Custom detail message";
 		$status = 406;
@@ -104,7 +104,7 @@ class BaseSerializerExceptionTest extends CakeTestCase {
 	 *
 	 * @return void
 	 */
-	public function testMagicCallMethod() {
+	public function testBaseMagicCallMethod() {
 		$title = "New Title";
 		$detail = "Custom detail message";
 		$status = 406;
@@ -143,4 +143,95 @@ class BaseSerializerExceptionTest extends CakeTestCase {
 		$testBaseSerializerException->getSomething();
 	}
 
+	/**
+	 * Confirm that the construct sets our values properly
+	 *
+	 * @return void
+	 */
+	public function testValidationConstructor() {
+		$title = "New Title";
+		$validationErrors = array(
+			'username' => array(
+				"Username can not be empty",
+				"Username can only be alphanumeric",
+			),
+			'first_name' => array(
+				"First Name can only be alphanumeric and not empty",
+			),
+		);
+		$status = 422;
+
+		$testValidationBaseSerializerException = new ValidationBaseSerializerException(
+			$title,
+			$validationErrors,
+			$status
+		);
+
+		$this->assertInstanceOf('ValidationBaseSerializerException', $testValidationBaseSerializerException);
+		$this->assertInstanceOf('CakeException', $testValidationBaseSerializerException);
+
+		$this->assertEquals(
+			$title,
+			$testValidationBaseSerializerException->title,
+			"Title does not match {$title}"
+		);
+		$this->assertEquals(
+			$validationErrors,
+			$testValidationBaseSerializerException->validationErrors,
+			"Validation Errors does not match our input"
+		);
+		$this->assertEquals(
+			$status,
+			$testValidationBaseSerializerException->status,
+			"Status does not match {$status}"
+		);
+	}
+
+	/**
+	 * test the __call method
+	 *
+	 * @return void
+	 */
+	public function testValidationMagicCallMethod() {
+		$title = "New Title";
+		$validationErrors = array(
+			'username' => array(
+				"Username can not be empty",
+				"Username can only be alphanumeric",
+			),
+			'first_name' => array(
+				"First Name can only be alphanumeric and not empty",
+			),
+		);
+		$status = 422;
+
+		$testValidationBaseSerializerException = new ValidationBaseSerializerException(
+			$title,
+			$validationErrors,
+			$status
+		);
+
+		$this->assertEquals(
+			$title,
+			$testValidationBaseSerializerException->title(),
+			"ValidationBaseSerializerException::title() should match our passed in `title`: {$title}"
+		);
+
+		$this->assertEquals(
+			$status,
+			$testValidationBaseSerializerException->status(),
+			"ValidationBaseSerializerException::status() should match our passed in `status`: {$status}"
+		);
+
+		$this->assertEquals(
+			$validationErrors,
+			$testValidationBaseSerializerException->validationErrors(),
+			"ValidationBaseSerializerException::validationErrors() should match our passed in `detail`"
+		);
+
+		$this->setExpectedException(
+			'BadMethodCallException', "No method or property ::getSomething for this class"
+		);
+		$testValidationBaseSerializerException->getSomething();
+	}
 }

--- a/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
+++ b/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
@@ -49,6 +49,16 @@ class TestSerializerExceptionRenderer extends SerializerExceptionRenderer {
 	/**
 	 * calls parent method
 	 *
+	 * @param ValidationBaseSerializerException $error the ValidationBaseSerializerException error to render
+	 * @return void
+	 */
+	public function renderValidationSerializerException(ValidationBaseSerializerException $error) {
+		return parent::renderValidationSerializerException($error);
+	}
+
+	/**
+	 * calls parent method
+	 *
 	 * @param HttpException $error an instance of HttpException
 	 * @return void
 	 */
@@ -257,6 +267,23 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 	 * @return void
 	 */
 	public function testRender() {
+		$exception = new ValidationBaseSerializerException();
+		$mockRenderer = $this->getMock('TestSerializerExceptionRenderer',
+			array('renderValidationSerializerException'),
+			array($exception)
+		);
+		$mockRenderer->expects($this->once())
+			->method('renderValidationSerializerException')
+			->with($exception)
+			->will($this->returnValue("renderValidationSerializerException"));
+		$mockRenderer->error = $exception;
+
+		$this->assertEquals(
+			"renderValidationSerializerException",
+			$mockRenderer->render(),
+			"render did not return our mocked value `renderValidationSerializerException` for a ValidationBaseSerializerException"
+		);
+
 		$exception = new BaseSerializerException();
 		$mockRenderer = $this->getMock('TestSerializerExceptionRenderer',
 			array('renderSerializerException'),
@@ -270,7 +297,7 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 
 		$this->assertEquals(
 			"renderSerializerException",
-			$mockRenderer->render($exception),
+			$mockRenderer->render(),
 			"render did not return our mocked value `renderSerializerException` for a BaseSerializerException"
 		);
 
@@ -287,7 +314,7 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 
 		$this->assertEquals(
 			"renderCakeException",
-			$mockRenderer->render($exception),
+			$mockRenderer->render(),
 			"render did not return our mocked value `renderCakeException` for a CakeException"
 		);
 
@@ -304,11 +331,11 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 
 		$this->assertEquals(
 			"renderHttpException",
-			$mockRenderer->render($exception),
+			$mockRenderer->render(),
 			"render did not return our mocked value `renderHttpException` for a HttpException"
 		);
 
-		$exception = new Exception();
+		$exception = new Exception("Default Exception");
 		$mockRenderer = $this->getMock('TestSerializerExceptionRenderer',
 			array('render'),
 			array($exception)
@@ -320,7 +347,7 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 
 		$this->assertEquals(
 			"render",
-			$mockRenderer->render($exception),
+			$mockRenderer->render(),
 			"render did not return our mocked value `render` for a Exception"
 		);
 	}
@@ -520,7 +547,7 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 	}
 
 	/**
-	 * test the renderSerializerException method when calling renderCakeAsJson
+	 * test the renderSerializerException method when calling renderSerializerAsJson
 	 *
 	 * @return void
 	 */
@@ -549,7 +576,7 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 	}
 
 	/**
-	 * test the renderSerializerException method when calling defaultCakeRender
+	 * test the renderSerializerException method when calling defaultSerializerRender
 	 *
 	 * @return void
 	 */
@@ -574,6 +601,90 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 			"defaultSerializerRender",
 			$mockRenderer->renderSerializerException($exception),
 			"renderSerializerException did not return our mocked value"
+		);
+	}
+
+	/**
+	 * test the renderValidationSerializerException method when calling renderValidationSerializerAsJsonApi
+	 *
+	 * @return void
+	 */
+	public function testRenderValidationSerializerExceptionJsonApiRequest() {
+		$exception = new ValidationBaseSerializerException();
+		$mockRenderer = $this->getMock('TestSerializerExceptionRenderer',
+			array('isJsonApiRequest', 'renderValidationSerializerAsJsonApi'),
+			array($exception)
+		);
+		$mockRenderer->expects($this->once())
+			->method('isJsonApiRequest')
+			->will($this->returnValue(true));
+		$mockRenderer->expects($this->once())
+			->method('renderValidationSerializerAsJsonApi')
+			->with($exception)
+			->will($this->returnValue("renderValidationSerializerAsJsonApi"));
+
+		$this->assertEquals(
+			"renderValidationSerializerAsJsonApi",
+			$mockRenderer->renderValidationSerializerException($exception),
+			"renderValidationSerializerException did not return our mocked value"
+		);
+	}
+
+	/**
+	 * test the renderValidationSerializerException method when calling renderValidationSerializerAsJson
+	 *
+	 * @return void
+	 */
+	public function testRenderValidationSerializerExceptionJsonRequest() {
+		$exception = new ValidationBaseSerializerException();
+		$mockRenderer = $this->getMock('TestSerializerExceptionRenderer',
+			array('isJsonApiRequest', 'isJsonRequest', 'renderValidationSerializerAsJson'),
+			array($exception)
+		);
+		$mockRenderer->expects($this->once())
+			->method('isJsonApiRequest')
+			->will($this->returnValue(false));
+		$mockRenderer->expects($this->once())
+			->method('isJsonRequest')
+			->will($this->returnValue(true));
+		$mockRenderer->expects($this->once())
+			->method('renderValidationSerializerAsJson')
+			->with($exception)
+			->will($this->returnValue("renderValidationSerializerAsJson"));
+
+		$this->assertEquals(
+			"renderValidationSerializerAsJson",
+			$mockRenderer->renderValidationSerializerException($exception),
+			"renderValidationSerializerException did not return our mocked value"
+		);
+	}
+
+	/**
+	 * test the renderValidationSerializerException method when calling defaultValidationSerializerRender
+	 *
+	 * @return void
+	 */
+	public function testRenderValidationSerializerExceptionDefaultRequest() {
+		$exception = new ValidationBaseSerializerException();
+		$mockRenderer = $this->getMock('TestSerializerExceptionRenderer',
+			array('isJsonApiRequest', 'isJsonRequest', 'defaultValidationSerializerRender'),
+			array($exception)
+		);
+		$mockRenderer->expects($this->once())
+			->method('isJsonApiRequest')
+			->will($this->returnValue(false));
+		$mockRenderer->expects($this->once())
+			->method('isJsonRequest')
+			->will($this->returnValue(false));
+		$mockRenderer->expects($this->once())
+			->method('defaultValidationSerializerRender')
+			->with($exception)
+			->will($this->returnValue("defaultValidationSerializerRender"));
+
+		$this->assertEquals(
+			"defaultValidationSerializerRender",
+			$mockRenderer->renderValidationSerializerException($exception),
+			"renderValidationSerializerException did not return our mocked value"
 		);
 	}
 

--- a/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
+++ b/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
@@ -1106,20 +1106,21 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 			$exceptionRenderer->controller->response->type(),
 			"Our Response Type does not equal application/json"
 		);
-		$this->assertArrayHasKey(
-			"title",
-			$exceptionRenderer->controller->viewVars,
-			"We do not have an title viewVars"
+
+		$this->assertInternalType(
+			"string",
+			$exceptionRenderer->controller->response->body(),
+			"Our body is not a string"
 		);
-		$this->assertArrayHasKey(
-			"validationErrors",
-			$exceptionRenderer->controller->viewVars,
-			"We do not have an validationErrors viewVars"
+		$this->assertInstanceOf(
+			"stdClass",
+			json_decode($exceptionRenderer->controller->response->body()),
+			"Our body is not a json_encoded array"
 		);
-		$this->assertArrayHasKey(
-			"status",
-			$exceptionRenderer->controller->viewVars,
-			"We do not have an status viewVars"
+		$this->assertSame(
+			'{"errors":{"username":["Username can not be empty","Username can only be alphanumeric"],"first_name":["First Name can only be alphanumeric and not empty"]}}',
+			$exceptionRenderer->controller->response->body(),
+			"Our body does not match the expected string"
 		);
 		$this->assertSame(
 			'cake-response-send',
@@ -1169,7 +1170,7 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 			"Our body is not a json_encoded array"
 		);
 		$this->assertSame(
-			'{"errors":{"username":["Username can not be empty","Username can only be alphanumeric"],"first_name":["First Name can only be alphanumeric and not empty"]}}',
+			'{"errors":{"id":"","href":"","status":"422","code":"422","title":"User Failed Validation","detail":{"username":["Username can not be empty","Username can only be alphanumeric"],"first_name":["First Name can only be alphanumeric and not empty"]},"links":"","paths":""}}',
 			$exceptionRenderer->controller->response->body(),
 			"Our body does not match the expected string"
 		);

--- a/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
+++ b/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
@@ -1282,7 +1282,7 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 	 * @return void
 	 */
 	public function testAddHttpCodes() {
-		$httpCodesAdded = array(422 => 'Unprocessable Entity',);
+		$httpCodesAdded = array(422 => 'Unprocessable Entity');
 
 		$mockController = $this->getMock('Controller', array('render', 'here'));
 		$mockController->request = new CakeRequest();

--- a/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
+++ b/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
@@ -335,20 +335,20 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 			"render did not return our mocked value `renderHttpException` for a HttpException"
 		);
 
-		$exception = new Exception("Default Exception");
+		$exception = new Exception("Default Exception", 400);
 		$mockRenderer = $this->getMock('TestSerializerExceptionRenderer',
-			array('render'),
+			array('error500'),
 			array($exception)
 		);
 		$mockRenderer->expects($this->once())
-			->method('render')
-			->will($this->returnValue("render"));
+			->method('error500')
+			->with($exception)
+			->will($this->returnValue("error500"));
 		$mockRenderer->error = $exception;
-
 		$this->assertEquals(
-			"render",
+			"error500",
 			$mockRenderer->render(),
-			"render did not return our mocked value `render` for a Exception"
+			"render did not return our mocked value `error500` for a standard Exception"
 		);
 	}
 

--- a/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
+++ b/Test/Case/Lib/Error/SerializerExceptionRendererTest.php
@@ -139,6 +139,45 @@ class TestSerializerExceptionRenderer extends SerializerExceptionRenderer {
 	/**
 	 * calls parent method
 	 *
+	 * @param ValidationBaseSerializerException $error an instance of ValidationBaseSerializerException
+	 * @return void
+	 */
+	public function defaultValidationSerializerRender(ValidationBaseSerializerException $error) {
+		return parent::defaultValidationSerializerRender($error);
+	}
+
+	/**
+	 * calls parent method
+	 *
+	 * @param ValidationBaseSerializerException $error an instance of ValidationBaseSerializerException
+	 * @return void
+	 */
+	public function renderValidationSerializerAsJson(ValidationBaseSerializerException $error) {
+		return parent::renderValidationSerializerAsJson($error);
+	}
+
+	/**
+	 * calls parent method
+	 *
+	 * @param ValidationBaseSerializerException $error an instance of ValidationBaseSerializerException
+	 * @return void
+	 */
+	public function renderValidationSerializerAsJsonApi(ValidationBaseSerializerException $error) {
+		return parent::renderValidationSerializerAsJsonApi($error);
+	}
+
+	/**
+	 * calls parent method
+	 *
+	 * @return void
+	 */
+	public function addHttpCodes() {
+		return parent::addHttpCodes();
+	}
+
+	/**
+	 * calls parent method
+	 *
 	 * @return bool returns true if JsonApi media request, false otherwise
 	 */
 	public function isJsonApiRequest() {
@@ -981,6 +1020,167 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 	}
 
 	/**
+	 * test the defaultValidationSerializerRender method
+	 *
+	 * @return void
+	 */
+	public function testDefaultValidationSerializerRender() {
+		$validationErrors = array(
+			'username' => array(
+				"Username can not be empty",
+				"Username can only be alphanumeric",
+			),
+			'first_name' => array(
+				"First Name can only be alphanumeric and not empty",
+			),
+		);
+		$validationBaseSerializerException = new ValidationBaseSerializerException("User Failed Validation", $validationErrors);
+		$exceptionRenderer = $this->returnRenderer('text/html', $validationBaseSerializerException);
+
+		$response = $exceptionRenderer->defaultValidationSerializerRender($validationBaseSerializerException);
+
+		$this->assertEquals(
+			"422",
+			$exceptionRenderer->controller->response->statusCode(),
+			"Our Controller Response Status Code does not equal `422`"
+		);
+		$this->assertEquals(
+			'text/html',
+			$exceptionRenderer->controller->response->type(),
+			"Our Response Type does not equal `text/html`"
+		);
+		$this->assertArrayHasKey(
+			"title",
+			$exceptionRenderer->controller->viewVars,
+			"We do not have an `title` viewVars"
+		);
+		$this->assertArrayHasKey(
+			"validationErrors",
+			$exceptionRenderer->controller->viewVars,
+			"We do not have an `validationErrors` viewVars"
+		);
+		$this->assertArrayHasKey(
+			"status",
+			$exceptionRenderer->controller->viewVars,
+			"We do not have an `status` viewVars"
+		);
+		$this->assertArrayHasKey(
+			"error",
+			$exceptionRenderer->controller->viewVars,
+			"We do not have an `error` viewVars"
+		);
+		$this->assertSame(
+			'cake-response-send',
+			$response,
+			"Our response does not match the expected string"
+		);
+	}
+
+	/**
+	 * test the renderValidationSerializerAsJson method
+	 *
+	 * @return void
+	 */
+	public function testRenderValidationSerializerAsJson() {
+		$validationErrors = array(
+			'username' => array(
+				"Username can not be empty",
+				"Username can only be alphanumeric",
+			),
+			'first_name' => array(
+				"First Name can only be alphanumeric and not empty",
+			),
+		);
+		$validationBaseSerializerException = new ValidationBaseSerializerException("User Failed Validation", $validationErrors);
+		$exceptionRenderer = $this->returnRenderer('application/json', $validationBaseSerializerException);
+
+		$response = $exceptionRenderer->renderValidationSerializerAsJson($validationBaseSerializerException);
+
+		$this->assertEquals(
+			"422",
+			$exceptionRenderer->controller->response->statusCode(),
+			"Our Controller Response Status Code does not equal 422"
+		);
+		$this->assertEquals(
+			"application/json",
+			$exceptionRenderer->controller->response->type(),
+			"Our Response Type does not equal application/json"
+		);
+		$this->assertArrayHasKey(
+			"title",
+			$exceptionRenderer->controller->viewVars,
+			"We do not have an title viewVars"
+		);
+		$this->assertArrayHasKey(
+			"validationErrors",
+			$exceptionRenderer->controller->viewVars,
+			"We do not have an validationErrors viewVars"
+		);
+		$this->assertArrayHasKey(
+			"status",
+			$exceptionRenderer->controller->viewVars,
+			"We do not have an status viewVars"
+		);
+		$this->assertSame(
+			'cake-response-send',
+			$response,
+			"Our response does not match the expected string"
+		);
+	}
+
+	/**
+	 * test the renderValidationSerializerAsJsonApi method
+	 *
+	 * @return void
+	 */
+	public function testRenderValidationSerializerAsJsonApi() {
+		$validationErrors = array(
+			'username' => array(
+				"Username can not be empty",
+				"Username can only be alphanumeric",
+			),
+			'first_name' => array(
+				"First Name can only be alphanumeric and not empty",
+			),
+		);
+		$validationBaseSerializerException = new ValidationBaseSerializerException("User Failed Validation", $validationErrors);
+		$exceptionRenderer = $this->returnRenderer('application/vnd.api+json', $validationBaseSerializerException);
+
+		$response = $exceptionRenderer->renderValidationSerializerAsJsonApi($validationBaseSerializerException);
+
+		$this->assertEquals(
+			"422",
+			$exceptionRenderer->controller->response->statusCode(),
+			"Our Controller Response Status Code does not equal 422"
+		);
+		$this->assertEquals(
+			"application/vnd.api+json",
+			$exceptionRenderer->controller->response->type(),
+			"Our Response Type does not equal application/vnd.api+json"
+		);
+		$this->assertInternalType(
+			"string",
+			$exceptionRenderer->controller->response->body(),
+			"Our body is not a string"
+		);
+		$this->assertInstanceOf(
+			"stdClass",
+			json_decode($exceptionRenderer->controller->response->body()),
+			"Our body is not a json_encoded array"
+		);
+		$this->assertSame(
+			'{"errors":{"username":["Username can not be empty","Username can only be alphanumeric"],"first_name":["First Name can only be alphanumeric and not empty"]}}',
+			$exceptionRenderer->controller->response->body(),
+			"Our body does not match the expected string"
+		);
+		$this->assertSame(
+			'cake-response-send',
+			$response,
+			"Our response does not match the expected string"
+		);
+	}
+
+	/**
 	 * test the isJsonApiRequest method when returns true
 	 *
 	 * @return void
@@ -1073,6 +1273,32 @@ class SerializerExceptionRendererTest extends CakeTestCase {
 			false,
 			$exceptionRenderer->isJsonRequest(),
 			"::isJsonRequest should have returned false, when we have the accepts header returning false"
+		);
+	}
+
+	/**
+	 * test the isJsonRequest method when returns false
+	 *
+	 * @return void
+	 */
+	public function testAddHttpCodes() {
+		$httpCodesAdded = array(422 => 'Unprocessable Entity',);
+
+		$mockController = $this->getMock('Controller', array('render', 'here'));
+		$mockController->request = new CakeRequest();
+		$mockController->response = $this->getMock('CakeResponse');
+		$mockController->response->expects($this->once())
+			->method('httpCodes')
+			->with($httpCodesAdded)
+			->will($this->returnValue(null));
+
+		$exceptionRenderer = new TestSerializerExceptionRenderer(new Exception());
+		$exceptionRenderer->controller = $mockController;
+
+		$this->assertEquals(
+			null,
+			$exceptionRenderer->addHttpCodes(),
+			"::addHttpCodes should have returned void"
 		);
 	}
 

--- a/View/Errors/validation_serializer_exception.ctp
+++ b/View/Errors/validation_serializer_exception.ctp
@@ -1,0 +1,24 @@
+<h2><?php echo __d('json_api_exceptions', $title); ?></h2>
+<p class="error">
+
+	<strong><?php echo __d('json_api_exceptions', 'Validation Errors'); ?>: </strong>
+	<?php echo var_dump($validationErrors); ?>
+	<br>
+
+	<strong><?php echo __d('json_api_exceptions', 'File'); ?>: </strong>
+	<?php echo h($error->getFile()); ?>
+	<br>
+
+	<strong><?php echo __d('json_api_exceptions', 'Line'); ?>: </strong>
+	<?php echo h($error->getLine()); ?>
+	<br>
+
+	<strong><?php echo __d('json_api_exceptions', 'HTTP Error Code'); ?>: </strong>
+	<?php echo h($status); ?>
+	<br>
+</p>
+<?php
+if (extension_loaded('xdebug')) {
+	xdebug_print_function_stack();
+}
+?>


### PR DESCRIPTION
Creates a new class ValidationBaseSerializerException extends CakeException
Renders ValidationBaseSerializerException matching the expected formats provided
